### PR TITLE
fix: add output encoding in 04-messaging.js

### DIFF
--- a/content/04-messaging.js
+++ b/content/04-messaging.js
@@ -63,8 +63,21 @@
             const name = (slot.getAttribute('data-subreddit') || '').toLowerCase();
             if (!name || slot.getAttribute('data-icon-applied') === '1') return;
             const icon = iconCache.get(name);
-            if (icon) {
-                slot.innerHTML = `<span class="inline-block rounded-full relative h-full w-full"><img src="${icon}" alt="" class="ghostddit-icon-img mb-0 shreddit-subreddit-icon__icon rounded-full overflow-hidden w-full h-full" width="24" style="width:24px;height:24px;object-fit:cover;" loading="lazy" onerror="this.remove();"></span>`;
+            if (icon && /^https?:\/\//i.test(icon)) {
+                const span = document.createElement('span');
+                span.className = 'inline-block rounded-full relative h-full w-full';
+                const img = document.createElement('img');
+                img.src = icon;
+                img.alt = '';
+                img.className = 'ghostddit-icon-img mb-0 shreddit-subreddit-icon__icon rounded-full overflow-hidden w-full h-full';
+                img.width = 24;
+                img.style.width = '24px';
+                img.style.height = '24px';
+                img.style.objectFit = 'cover';
+                img.loading = 'lazy';
+                img.addEventListener('error', () => img.remove());
+                span.appendChild(img);
+                slot.replaceChildren(span);
                 slot.setAttribute('data-icon-applied', '1');
             }
         });
@@ -89,9 +102,13 @@
     }
 
     function getCookie(name) {
-        const escaped = name.replace(/([.$?*|{}()[\]\\/+^])/g, '\\$1');
-        const match = document.cookie.match(new RegExp('(?:^|; )' + escaped + '=([^;]*)'));
-        return match ? decodeURIComponent(match[1]) : null;
+        for (const part of document.cookie.split('; ')) {
+            const idx = part.indexOf('=');
+            if (idx !== -1 && part.slice(0, idx) === name) {
+                return decodeURIComponent(part.slice(idx + 1));
+            }
+        }
+        return null;
     }
 
     async function shredditGraphql(operation, variables) {


### PR DESCRIPTION
## Summary
Fix high severity security issue in `content/04-messaging.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `content/04-messaging.js:56` |
| **Assessment** | Likely exploitable |
| **CWE** | CWE-79 |

**Description**: The extension renders Reddit API response data directly into the DOM using innerHTML without proper sanitization. Subreddit icons and comment data fetched from Reddit's API are inserted via innerHTML interpolation. An attacker can post malicious content to Reddit containing XSS payloads that will execute when the extension renders this content.

## Evidence

**Exploitation scenario**: An attacker creates a subreddit with a malicious icon URL containing a JavaScript payload (e.g., 'javascript:alert(document.cookie)' or an SVG with embedded scripts).

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Changes
- `content/04-messaging.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=V-001 scanner=multi_agent_ai -->
